### PR TITLE
Fix dialyzer warning

### DIFF
--- a/src/rabbit_exchange_type_management.erl
+++ b/src/rabbit_exchange_type_management.erl
@@ -13,7 +13,7 @@
 
 -export([description/0, serialise_events/0, route/2]).
 -export([validate/1, validate_binding/2,
-         create/2, delete/3, policy_changed/2,
+         create/2, delete/2, policy_changed/2,
          add_binding/3, remove_bindings/3, assert_args_equivalence/2]).
 -export([info/1, info/2]).
 
@@ -57,7 +57,7 @@ validate(_X) -> ok.
 validate_binding(_X, _B) -> {error, {'binding_invalid', "cannot_bind_to_management_exchange", []}}.
 
 create(_Tx, _X)          -> ok.
-delete(_Tx, _X, _Bs)     -> ok.
+delete(_Tx, _X)          -> ok.
 policy_changed(_X1, _X2) -> ok.
 
 -spec add_binding(any(), any(), any()) -> no_return().


### PR DESCRIPTION
`rabbit_exchange_type` behaviour has changed in rabbitmq-server